### PR TITLE
namespace is automatically specified as required

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,6 +30,10 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
+
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.zero.app_installer'
+    }
 }
 
 dependencies {


### PR DESCRIPTION
To fix namespace not specified. Specify a namespace in the module's build file.